### PR TITLE
Make Hopper compile with Linux g++

### DIFF
--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <iostream>
 #include <math.h>
+#include <cstring>
 #include "Engine.h"
 
 namespace Hopper


### PR DESCRIPTION
This PR fixes the issue of a missing memcpy declaration in Engine.cpp. Now Hopper will properly compile and run on Linux. (Debian 11 Bullseye).